### PR TITLE
luxmark: hide compilation dialog on errors like CL_OUT_OF_HOST_MEMORY

### DIFF
--- a/src/luxmarkapp.cpp
+++ b/src/luxmarkapp.cpp
@@ -249,8 +249,10 @@ void LuxMarkApp::EngineInitThreadImpl(LuxMarkApp *app) {
 		app->engineInitDone = true;
 	} catch (runtime_error &err) {
 		LM_ERROR("RUNTIME ERROR: " << err.what());
+		LM_HIDE_KERNEL_COMPILATION_DIALOG;
 	} catch (exception &err) {
 		LM_ERROR("ERROR: " << err.what());
+		LM_HIDE_KERNEL_COMPILATION_DIALOG;
 	}
 }
 


### PR DESCRIPTION
The compilation dialog should be hidden if the OpenCL kernel compilation failed, and not let the application in an unusable state with all inputs disabled.

This makes sure the application remains in an usable state when OpenCL compilation fails with errors like that:

```
RUNTIME ERROR: OpenCL driver API error (code: -6, file:LuxCore/src/luxrays/devices/ocldevice.cpp, line: 143): CL_OUT_OF_HOST_MEMORY 
```

This work is courtesy of [I ♥ Compute](https://gitlab.com/illwieckz/i-love-compute) initiative funded by [🇫🇷️ rebatir.fr](https://rebatir.fr/).