### PR TITLE
cmake: fix building with recent Oidn

### DIFF
--- a/cmake/Packages/FindOidn.cmake
+++ b/cmake/Packages/FindOidn.cmake
@@ -14,10 +14,10 @@
 ## limitations under the License.                                           ##
 ## ======================================================================== ##
 
-FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/version.h PATHS
+FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/config.h PATHS
 	${OIDN_ROOT}/include)
 IF (NOT OIDN_INCLUDE_PATH)
-	FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/version.h PATHS
+	FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/config.h PATHS
 		/usr/include
 		/usr/local/include
 		/opt/local/include)


### PR DESCRIPTION
Oidn commit https://github.com/OpenImageDenoise/oidn/commit/a0a5cbe9c644b4bda8fae88211b065f72a68eef6 renamed `version.h` to `config.h`.

This work is courtesy of [I ♥ Compute](https://gitlab.com/illwieckz/i-love-compute) initiative funded by [🇫🇷️ rebatir.fr](https://rebatir.fr/).